### PR TITLE
Updated to use NLog AsyncTaskTarget

### DIFF
--- a/src/NLog.Azure.Kusto.Tests/ADXSinkE2ETest.cs
+++ b/src/NLog.Azure.Kusto.Tests/ADXSinkE2ETest.cs
@@ -88,8 +88,8 @@ namespace NLog.Azure.Kusto.Tests
                 for (int i = 0; i < retries; i++)
                 {
                     await Task.Delay(delayTime);
-                    reader = kustoClient.ExecuteQuery(m_generatedTableName + " | where Message contains \"" + testType + "\" | count; " +
-                        m_generatedTableName + " | where Message contains \"" + testType + "\" and  not(isempty(Exception))  | count");
+                    reader = kustoClient.ExecuteQuery(m_generatedTableName + " | where FormattedMessage contains \"" + testType + "\" | count; " +
+                        m_generatedTableName + " | where FormattedMessage contains \"" + testType + "\" and  not(isempty(Exception))  | count");
                     while (reader.Read())
                     {
                         count = reader.GetInt64(0);

--- a/src/NLog.Azure.Kusto.Tests/ADXTargetTest.cs
+++ b/src/NLog.Azure.Kusto.Tests/ADXTargetTest.cs
@@ -7,7 +7,7 @@ namespace NLog.Azure.Kusto.Tests
     {
         private static ADXTarget GetTarget(string configfile)
         {
-            LogManager.LoadConfiguration(Path.Combine("config", configfile + ".config"));
+            LogManager.Setup().LoadConfigurationFromFile(Path.Combine("config", configfile + ".config"), optional: false);
             return LogManager.Configuration.AllTargets.OfType<ADXTarget>().First();
         }
 

--- a/src/NLog.Azure.Kusto/ADXLogEvent.cs
+++ b/src/NLog.Azure.Kusto/ADXLogEvent.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace NLog.Azure.Kusto
 {
@@ -9,18 +10,45 @@ namespace NLog.Azure.Kusto
         public string Message { get; set; }
         public string Exception { get; set; }
         public string FormattedMessage { get; set; }
+        [JsonConverter(typeof(UnsafeRawJsonConverter))]
         public string Properties { get; set; }
-        public static ADXLogEvent GetADXLogEvent(LogEventInfo logEventInfo, string renderedMessage)
+        public static ADXLogEvent GetADXLogEvent(LogEventInfo logEventInfo, string renderedMessage, string renderedJsonProperties)
         {
             return new ADXLogEvent
             {
                 Level = logEventInfo.Level.ToString(),
-                Timestamp = logEventInfo.TimeStamp,
-                Message = logEventInfo.FormattedMessage,
+                Timestamp = logEventInfo.TimeStamp.ToUniversalTime(),
+                Message = logEventInfo.Message,
                 FormattedMessage = renderedMessage,
                 Exception = logEventInfo.Exception?.ToString(),
-                Properties = logEventInfo.Properties?.Count == 0 ? "{}" : System.Text.Json.JsonSerializer.Serialize(logEventInfo.Properties)
+                Properties = renderedJsonProperties,
             };
         }
+    }
+
+    /// <summary>
+    /// Serializes the contents of a string value as raw JSON.  The string is validated as being an RFC 8259-compliant JSON payload
+    /// </summary>
+    public class RawJsonConverter : JsonConverter<string>
+    {
+        public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            using var doc = JsonDocument.ParseValue(ref reader);
+            return doc.RootElement.GetRawText();
+        }
+
+        protected virtual bool SkipInputValidation => false;
+
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options) =>
+            // skipInputValidation : true will improve performance, but only do this if you are certain the value represents well-formed JSON!
+            writer.WriteRawValue(value, skipInputValidation: SkipInputValidation);
+    }
+
+    /// <summary>
+    /// Serializes the contents of a string value as raw JSON.  The string is NOT validated as being an RFC 8259-compliant JSON payload
+    /// </summary>
+    public class UnsafeRawJsonConverter : RawJsonConverter
+    {
+        protected override bool SkipInputValidation => true;
     }
 }

--- a/src/NLog.Azure.Kusto/ADXTarget.cs
+++ b/src/NLog.Azure.Kusto/ADXTarget.cs
@@ -1,26 +1,27 @@
 ﻿using System;
-using Kusto.Ingest;
-using Kusto.Data;
-using NLog.Targets;
 using System.IO;
-using Microsoft.IO;
 using System.IO.Compression;
 using System.Text.Json;
+using Kusto.Ingest;
+using Kusto.Data;
 using Kusto.Data.Common;
+using Microsoft.IO;
 using NLog.Config;
+using NLog.Layouts;
+using NLog.Targets;
 
 namespace NLog.Azure.Kusto
 {
     [Target("ADXTarget")]
-    public class ADXTarget : TargetWithLayout
+    public class ADXTarget : AsyncTaskTarget
     {
         ADXSinkOptions options;
         private IKustoIngestClient m_ingestClient;
         private IngestionMapping m_ingestionMapping;
         private bool m_disposed;
         private bool m_streamingIngestion;
-        private int m_ingestionTimeout; //seconds
         private static readonly RecyclableMemoryStreamManager SRecyclableMemoryStreamManager = new RecyclableMemoryStreamManager();
+        private readonly JsonLayout _jsonLayoutProperties = new JsonLayout() { IncludeEventProperties = true, MaxRecursionLimit = 10 };
 
         [RequiredParameter]
         public string Database { get; set; }
@@ -37,8 +38,11 @@ namespace NLog.Azure.Kusto
         public string FlushImmediately { get; set; } = "false";
         public string MappingNameRef { get; set; }
 
-
-        public string IngestionTimout { get; set; }
+        public ADXTarget()
+        {
+            Layout = "${logger}|${message}";
+            IncludeEventProperties = true;
+        }
 
         protected override void InitializeTarget()
         {
@@ -57,7 +61,6 @@ namespace NLog.Azure.Kusto
             SetupAuthCredentials(options, defaultLogEvent);
             m_streamingIngestion = options.UseStreamingIngestion;
             m_ingestionMapping = new IngestionMapping();
-            m_ingestionTimeout = RenderLogEvent(IngestionTimout, defaultLogEvent) == "" ? 0 : int.Parse(RenderLogEvent(IngestionTimout, defaultLogEvent));
 
             if (!string.IsNullOrEmpty(options.MappingName))
             {
@@ -71,6 +74,27 @@ namespace NLog.Azure.Kusto
                 ? KustoIngestFactory.CreateManagedStreamingIngestClient(engineKcsb, dmkcsb)
                 : KustoIngestFactory.CreateQueuedIngestClient(dmkcsb);
 
+            _jsonLayoutProperties.IncludeEventProperties = IncludeEventProperties;
+            if (ContextProperties?.Count > 0)
+            {
+                _jsonLayoutProperties.Attributes.Clear();
+                foreach (var contextProperty in ContextProperties)
+                {
+                    _jsonLayoutProperties.Attributes.Add(new JsonAttribute(contextProperty.Name, contextProperty.Layout));
+                }
+            }
+        }
+
+        protected override void CloseTarget()
+        {
+            try
+            {
+                m_ingestClient?.Dispose();
+            }
+            finally
+            {
+                m_ingestClient = null;
+            }
         }
 
         private void SetupAuthCredentials(ADXSinkOptions options, LogEventInfo defaultLogEvent)
@@ -91,9 +115,10 @@ namespace NLog.Azure.Kusto
             }
         }
 
-        protected override async void Write(LogEventInfo logEvent)
+        protected override async Task WriteAsyncTask(IList<LogEventInfo> logEvents, CancellationToken cancellationToken)
         {
-            using var datastream = CreateStreamFromLogEvents(ADXLogEvent.GetADXLogEvent(logEvent, RenderLogEvent(Layout, logEvent)));
+            using var datastream = CreateStreamFromLogEvents(logEvents);
+
             var sourceId = Guid.NewGuid();
             IKustoIngestionResult result;
             if (m_streamingIngestion)
@@ -129,14 +154,26 @@ namespace NLog.Azure.Kusto
             }
         }
 
-        private Stream CreateStreamFromLogEvents(ADXLogEvent adxloginfo)
+        protected override Task WriteAsyncTask(LogEventInfo logEvent, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();    // Will never be hit, with override of WriteAsyncTask(IList<LogEventInfo> logEvents)
+        }
+
+        private Stream CreateStreamFromLogEvents(IList<LogEventInfo> batch)
         {
             var stream = SRecyclableMemoryStreamManager.GetStream();
-
             using (GZipStream compressionStream = new GZipStream(stream, CompressionMode.Compress, leaveOpen: true))
             {
-                JsonSerializer.Serialize(compressionStream, adxloginfo);
+                for (int i = 0; i < batch.Count; ++i)
+                {
+                    var logEvent = batch[i];
+                    var logEventMessage = RenderLogEvent(Layout, logEvent);
+                    var logEventJsonProperties = RenderLogEvent(_jsonLayoutProperties, logEvent).NullIfEmpty() ?? "{}";
+                    var adxloginfo = ADXLogEvent.GetADXLogEvent(logEvent, logEventMessage, logEventJsonProperties);
+                    JsonSerializer.Serialize(compressionStream, adxloginfo);
+                }
             }
+
             stream.Seek(0, SeekOrigin.Begin);
             return stream;
         }
@@ -159,12 +196,12 @@ namespace NLog.Azure.Kusto
         }
         #endregion
     }
-    public static class StringExtensions
+
+    internal static class StringExtensions
     {
         public static string NullIfEmpty(this string s)
         {
             return string.IsNullOrEmpty(s) ? null : s;
         }
     }
-
 }


### PR DESCRIPTION
Resolves #5 - See also: https://github.com/NLog/NLog/wiki/How-to-write-a-custom-async-target

Notice it is now possible to add extra properties, besides those in the LogEvent:

```xml
    <target name="adxtarget" xsi:type="ADXTarget">
      <contextproperty name="MachineName" layout="${machinename}" />
      <contextproperty name="ThreadId" layout="${threadid}" />
    </target>
```

Notice it is now also possible to post multiple LogEvents in a single batch (if setting BatchSize > 1):
- **BatchSize** - Gets or sets the number of log events that should be processed in a batch by the lazy writer thread. (Default 1)
- **TaskDelayMilliseconds** - How many milliseconds to delay the actual write operation to optimize for batching (Default 1 ms)
- **QueueLimit** - Gets or sets the limit on the number of requests in the lazy writer thread request queue (Default 10000)
- **OverflowAction** - Gets or sets the action to be taken when the lazy writer thread request queue count exceeds the set limit (Default Discard).