### PR TITLE
Support for AuthenticationType = AadWorkloadIdentity

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ Add the ADX target to your NLog configuration:
 | Destination Option          | Description                                                                                                                                                                 |
 |:----------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | ConnectionString            | Kusto connection string. Eg: `Data Source=https://ingest-<clustername>.<region>.kusto.windows.net;Fed=True`. Read about [Kusto Connection String](https://learn.microsoft.com/azure/data-explorer/kusto/api/connection-strings/kusto)                                          |
-| Database                    | The name of the database to which data should be ingested into.                                                                                         |
-| TableName                   | The name of the table to which data should be ingested.                                                                                                                               |
-| ManagedIdentityClientId     | In case of ManagedIdentity Authentication, this need to be set for user assigned identity ("system" = SystemManagedIdentity)                                                |
-| AzCliAuth              | Enable ADX connector to use Azure CLI authentication                                                                                 |
+| Database                    | The name of the database to which data should be ingested into.                                                                                                             |
+| TableName                   | The name of the table to which data should be ingested.                                                                                                                     |
+| AuthenticationType          | Override the Authentication style, instead of ConnectionString providing authentication details                                                                             |
+| ManagedIdentityClientId     | Provides the user assigned identity with `AuthenticationType` = AadUserManagedIdentity                                                                                      |
 | FlushImmediately            | In case queued ingestion is selected, this property determines if is needed to flush the data immediately to ADX cluster. Not recommended to enable for data with higher workloads. The default is false. |
-| MappingNameRef              | Use a data mapping configured in ADX.                                                                                        |
+| MappingNameRef              | Use a data mapping configured in ADX.                                                                                                                                       |
 | ApplicationName             | Override default application-name                                                                                                                                           |
 | ApplicationVersion          | Override default application-version                                                                                                                                        |
 
@@ -62,7 +62,7 @@ Add the ADX target to your NLog configuration:
 |:----------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Layout                      | Formatting of the ADX-event FormattedMessage. The default is: `${logger}${message}`                                                                                         |
 | IncludeEventProperties      | Include LogEvent Properties in the ADX-event. The default is true                                                                                                           |
-| ContextProperty             | Include additional ContextProperties in the ADX-event. The default is empty collection.                                                                                           |
+| ContextProperty             | Include additional ContextProperties in the ADX-event. The default is empty collection.                                                                                     |
 | BatchSize                   | Gets or sets the number of log events that should be processed in a batch by the lazy writer thread. (Default 1)                                                            |
 | TaskDelayMilliseconds       | How many milliseconds to delay the actual send payload operation to optimize for batching (Default 1 ms)                                                                    |
 | QueueLimit                  | Gets or sets the limit on the number of requests in the lazy writer thread request queue (Default 10000)                                                                    |
@@ -94,14 +94,17 @@ This mapping can be overridden using the following options:
 
 Authentication will be taken according to the kusto connection string passed in the nlog target configuration.
 
-There are few cases to keep in mind for the following authentication modes:
-1. `Managed Identity Authentication`
-    * This authentication mode can be of two types System Assigned Managed Identity and User Assigned Managed Identity. In case of User Assigned Managed Identity, it requires the following properties to be set in the nlog target configuration::
-        * `ManagedIdentityClientId` :
-            * `system` : This will enable managed identity authentication for system assigned managed identity.
-            * `<clientId>`:  Setting `ManagedIdentityClientId` to a specific clientId will enable managed identity authentication for user assigned managed identity.
-2. `AzCliAuth`
-    * This authentication mode will use the Azure CLI to authenticate. This authentication mode will only work when the application is running on a machine with Azure CLI installed and logged in. Accepted values `true` or `false`. Default value is `false`.
+It is also possible to assign `AuthenticationType` to override the authentication mode.
+
+| AuthenticationType        | Method                                     | Notes                                                   |
+|---------------------------|--------------------------------------------|---------------------------------------------------------|
+| None                      | Default Mode                               | ConnectionString provides authentication details        |
+| AadUserManagedIdentity    | WithAadUserManagedIdentity                 | Apply ManagedIdentityClientId as User Assigned Identity |
+| AadSystemManagedIdentity  | WithAadSystemManagedIdentity               | Apply System Assigned Managed Identity                  |
+| AadWorkloadIdentity       | WithAadAzureTokenCredentialsAuthentication | WorkloadIdentityCredential for Kubernetes or other hosts|
+| AddAzCli                  | WithAadAzCliAuthentication                 | Azure CLI Authentication                                |
+| AadUserPrompt             | WithAadAzureTokenCredentialsAuthentication | **Recommended only for development!**                   |
+
 
 ### Running tests
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,18 +4,15 @@
   </PropertyGroup>
   <ItemGroup>
     <!--    add your PackageVersion nodes here -->
-    <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageVersion Include="Microsoft.Azure.Kusto.Data" Version="11.3.3" />
-    <PackageVersion Include="Microsoft.Azure.Kusto.Ingest" Version="11.3.3" />
-    <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
-    <PackageVersion Include="NLog" Version="5.1.4" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageVersion Include="xunit" Version="2.5.0-pre.11" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageVersion Include="Microsoft.Azure.Kusto.Ingest" Version="12.1.0" />
+    <PackageVersion Include="NLog" Version="5.2.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageVersion Include="xunit" Version="2.8.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
-    <PackageVersion Include="coverlet.collector" Version="6.0.0">
+    <PackageVersion Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>

--- a/src/NLog.Azure.Kusto.Tests/ADXSinkE2ETest.cs
+++ b/src/NLog.Azure.Kusto.Tests/ADXSinkE2ETest.cs
@@ -66,7 +66,7 @@ namespace NLog.Azure.Kusto.Tests
         [Theory]
         [InlineData("Test_ADXTargetStreamed", 10, 12, 30000)]
         [InlineData("Test_ADXNTargetBatched", 10, 12, 30000)]
-        public async void Test_LogMessage(string testType, int numberOfLogs, int retries, int delayTime)
+        public async Task Test_LogMessage(string testType, int numberOfLogs, int retries, int delayTime)
         {
             Logger logger = GetCustomLogger(testType);
             if (logger == null) throw new Exception("Logger/Test type not supported");
@@ -103,8 +103,6 @@ namespace NLog.Azure.Kusto.Tests
                 }
                 Assert.Equal(3 * numberOfLogs, count);
                 Assert.Equal(numberOfLogs, finalExpCount);
-
-
             }
         }
 

--- a/src/NLog.Azure.Kusto.sln
+++ b/src/NLog.Azure.Kusto.sln
@@ -9,6 +9,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLog.Azure.Kusto.Tests", "N
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLog.Azure.Kusto.Samples", "NLog.Azure.Kusto.Samples\NLog.Azure.Kusto.Samples.csproj", "{0A9C8D5E-F80A-44B6-A1DE-1C1A45A99348}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{47F2F7C6-0B05-4277-9D79-2450250F0D0B}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Packages.props = Directory.Packages.props
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/NLog.Azure.Kusto/AuthenticationType.cs
+++ b/src/NLog.Azure.Kusto/AuthenticationType.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NLog.Azure.Kusto
+{
+    /// <summary>
+    /// Possible options for override of authentication
+    /// </summary>
+    public enum AuthenticationType
+    {
+        /// <summary>
+        /// Use the authentication details provided by the ConnectionString
+        /// </summary>
+        None = 0,
+        /// <summary>
+        /// User assigned managed identity
+        /// </summary>
+        AadUserManagedIdentity = 1,
+        /// <summary>
+        /// System assigned managed identity
+        /// </summary>
+        AadSystemManagedIdentity = 2,
+        /// <summary>
+        /// Workload identity for kubernetes and other hosts
+        /// </summary>
+        AadWorkloadIdentity = 3,
+        /// <summary>
+        /// AzureCliCredential with fallback to InteractiveBrowserCredential
+        /// </summary>
+        AadUserPrompt = 4,
+        /// <summary>
+        /// Azure CLI Authentication
+        /// </summary>
+        AddAzCli = 5,
+    }
+}

--- a/src/NLog.Azure.Kusto/NLog.Azure.Kusto.csproj
+++ b/src/NLog.Azure.Kusto/NLog.Azure.Kusto.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-	<IsPackable>true</IsPackable>
+    <IsPackable>true</IsPackable>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageTags>nlog; nlog-sink; Azure Data Explorer; ADX; Kusto;kusto-nlog-target;</PackageTags>
+    <PackageTags>nlog; Azure Data Explorer; ADX; Kusto; Logging</PackageTags>
     <Title>Kusto NLog Sink</Title>
-	<authors>Microsoft</authors>
-	<copyright>© Microsoft Corporation. All rights reserved.</copyright>
-	<SignAssembly>true</SignAssembly>
-	<AssemblyOriginatorKeyFile>NLog.Azure.Kusto.snk</AssemblyOriginatorKeyFile>
-	<Version>2.0.1</Version>
+    <authors>Microsoft</authors>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>NLog.Azure.Kusto.snk</AssemblyOriginatorKeyFile>
+    <Version>2.0.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\README.md">
@@ -20,9 +20,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Kusto.Data" />
     <PackageReference Include="Microsoft.Azure.Kusto.Ingest" />
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
     <PackageReference Include="NLog" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Preview docs - https://github.com/snakefoot/azure-kusto-nlog-sink/blob/main/README.md

Kept magic value handling for `AzCliAuth` + `ManagedIdentityClientId` so non-breaking change.