### PR TITLE
Dependency Microsoft.Azure.Kusto.Ingest ver. 12.2.4

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,11 +4,11 @@
   </PropertyGroup>
   <ItemGroup>
     <!--    add your PackageVersion nodes here -->
-    <PackageVersion Include="Microsoft.Azure.Kusto.Ingest" Version="12.1.0" />
+    <PackageVersion Include="Microsoft.Azure.Kusto.Ingest" Version="12.2.4" />
     <PackageVersion Include="NLog" Version="5.2.2" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageVersion Include="xunit" Version="2.8.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.0">
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageVersion Include="xunit" Version="2.9.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>


### PR DESCRIPTION
Fix issue with breaking change in [Microsoft.IO.RecyclableMemoryStream](https://www.nuget.org/packages/Microsoft.IO.RecyclableMemoryStream/) (>= 3.0.0)

But maybe wait for 12.2.4, since it has [changelog](https://github.com/Azure/azure-kusto-dotnet/blob/main/Microsoft.Azure.Kusto.Ingest.changelog.md):
- Fixed unnecessary NuGet dependencies