### PR TITLE
[bugfix]:  Updated default batchingPoliciyTimeSpan

### DIFF
--- a/src/NLog.Azure.Kusto.Tests/ADXSinkE2ETest.cs
+++ b/src/NLog.Azure.Kusto.Tests/ADXSinkE2ETest.cs
@@ -47,7 +47,7 @@ namespace NLog.Azure.Kusto.Tests
             var alterBatchingPolicy = CslCommandGenerator.GenerateTableAlterIngestionBatchingPolicyCommand(
                 database,
                 m_generatedTableName,
-                new IngestionBatchingPolicy(TimeSpan.FromSeconds(1), 3, 1024));
+                new IngestionBatchingPolicy(TimeSpan.FromSeconds(10), 3, 1024));
 
             var enableStreamingIngestion = CslCommandGenerator.GenerateTableAlterStreamingIngestionPolicyCommand(
                 m_generatedTableName,


### PR DESCRIPTION

 The change modifies the ingestion batching policy to use a longer time interval.

Test configuration update:

* [`src/NLog.Azure.Kusto.Tests/ADXSinkE2ETest.cs`](diffhunk://#diff-42d15ec09c58b9f1c8feffe65d22f7eb98ce2af194bad83a6df3e156be65b7ceL50-R50): Updated the `IngestionBatchingPolicy` in the `public ADXSinkE2ETest()` method to increase the batching time interval from 1 second to 10 seconds.