### PR TITLE
Revert Unit-Test dependency update

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,8 +6,8 @@
     <!--    add your PackageVersion nodes here -->
     <PackageVersion Include="Microsoft.Azure.Kusto.Ingest" Version="13.0.2" />
     <PackageVersion Include="NLog" Version="5.2.5" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageVersion Include="xunit" Version="2.9.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Trying to fix issue with test-build failing, after being stuck for 42 mins (or longer):
```
Run dotnet test src -c Release --no-build --verbosity normal
Build started 05/26/2025 18:35:12.
     1>Project "/home/runner/work/azure-kusto-nlog-sink/azure-kusto-nlog-sink/src/NLog.Azure.Kusto.sln" on node 1 (VSTest target(s)).
     1>ValidateSolutionConfiguration:
         Building solution configuration "Release|Any CPU".
Test run for /home/runner/work/azure-kusto-nlog-sink/azure-kusto-nlog-sink/src/NLog.Azure.Kusto.Tests/bin/Release/net8.0/NLog.Azure.Kusto.Tests.dll (.NETCoreApp,Version=v8.0)
VSTest version 17.11.1 (x64)

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.8.2+699d445a1a (64-bit .NET 8.0.16)
[xUnit.net 00:00:00.07]   Discovering: NLog.Azure.Kusto.Tests
[xUnit.net 00:00:00.11]   Discovered:  NLog.Azure.Kusto.Tests
[xUnit.net 00:00:00.12]   Starting:    NLog.Azure.Kusto.Tests
Error: The operation was canceled.
```
https://github.com/Azure/azure-kusto-nlog-sink/actions/runs/15260128379/job/42916274447