### PR TITLE
Fix CI pipeline timeout and E2E test resilience

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,11 +11,12 @@ jobs:
 
     runs-on: ubuntu-latest
     environment: e2e
+    timeout-minutes: 15
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
     - name: Restore dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,236 @@
+# AGENTS.md
+
+> This file provides guidance for AI agents (GitHub Copilot, Copilot Workspace, etc.) working on this repository.
+
+## Project Overview
+
+**NLog.Azure.Kusto** is an NLog custom target that writes log events to [Azure Data Explorer (Kusto)](https://learn.microsoft.com/azure/data-explorer). It is published as the NuGet package [`NLog.Azure.Kusto`](https://www.nuget.org/packages/NLog.Azure.Kusto).
+
+- **Language:** C#
+- **Framework:** .NET 8.0, .NET Standard 2.0, .NET Framework 4.7.2 (multi-target)
+- **Logging framework:** [NLog](https://nlog-project.org/) (extends `AsyncTaskTarget`)
+- **Ingestion SDK:** [Microsoft.Azure.Kusto.Ingest](https://www.nuget.org/packages/Microsoft.Azure.Kusto.Ingest)
+- **Testing framework:** [xUnit](https://xunit.net/)
+- **License:** MIT
+- **Owner:** Microsoft / Azure
+
+## Repository Structure
+
+```
+├── AGENTS.md                          # AI agent guidance (this file)
+├── README.md                          # User-facing documentation
+├── CODE_OF_CONDUCT.md
+├── LICENSE
+├── SECURITY.md
+├── SUPPORT.md
+├── .github/
+│   └── workflows/
+│       ├── dotnet.yml                 # CI: build + test on push/PR to main
+│       └── nuget.yml                  # Manual NuGet publish workflow
+└── src/
+    ├── Directory.Build.props          # Shared MSBuild properties (all projects)
+    ├── Directory.Packages.props       # Centralized NuGet package versions
+    ├── NLog.Azure.Kusto.sln           # Solution file
+    ├── NLog.Azure.Kusto/              # Main library project
+    │   ├── NLog.Azure.Kusto.csproj
+    │   ├── ADXTarget.cs               # Core NLog target implementation
+    │   ├── ADXSinkOptions.cs          # Configuration & connection management
+    │   ├── ADXLogEvent.cs             # Log event model for Kusto ingestion
+    │   ├── AuthenticationType.cs      # Authentication mode enum
+    │   └── AssemblyInfo.cs
+    ├── NLog.Azure.Kusto.Tests/        # Unit & E2E tests
+    │   ├── NLog.Azure.Kusto.Tests.csproj
+    │   ├── ADXTargetTest.cs           # Unit tests (config loading)
+    │   ├── ADXSinkE2ETest.cs          # E2E tests (requires live ADX cluster)
+    │   ├── Usings.cs
+    │   └── config/                    # NLog test configuration files
+    └── NLog.Azure.Kusto.Samples/      # Sample console application
+        ├── NLog.Azure.Kusto.Samples.csproj
+        ├── Program.cs
+        └── NLog.config
+```
+
+## Build & Test
+
+### Prerequisites
+
+- [.NET 8.0 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) or later
+
+### Build
+
+```bash
+dotnet restore src
+dotnet build src -c Release
+```
+
+### Run Unit Tests
+
+```bash
+dotnet test src -c Release
+```
+
+### Run E2E Tests (requires live ADX cluster)
+
+E2E tests need environment variables pointing to an Azure Data Explorer cluster:
+
+```bash
+# Linux / macOS
+export CONNECTION_STRING="<your-kusto-connection-string>"
+export DATABASE="<your-database-name>"
+
+# Windows PowerShell
+$env:CONNECTION_STRING="<your-kusto-connection-string>"
+$env:DATABASE="<your-database-name>"
+```
+
+Then run:
+
+```bash
+dotnet test src -c Release --verbosity normal
+```
+
+### Run the Sample
+
+```bash
+dotnet run --project src/NLog.Azure.Kusto.Samples
+```
+
+## Dependency Management
+
+This project uses **centralized NuGet package version management**. All package versions are defined in:
+
+```
+src/Directory.Packages.props
+```
+
+Individual `.csproj` files reference packages **without** specifying a version — versions come from `Directory.Packages.props`. When updating a dependency, always update it in `Directory.Packages.props`, not in individual `.csproj` files.
+
+### Key Dependencies
+
+| Package | Purpose |
+|---------|---------|
+| `Microsoft.Azure.Kusto.Ingest` | Azure Data Explorer ingestion client |
+| `NLog` | NLog logging framework |
+| `Microsoft.NET.Test.Sdk` | .NET test platform SDK |
+| `xunit` | xUnit testing framework |
+| `xunit.runner.visualstudio` | xUnit VS Test adapter |
+| `coverlet.collector` | Code coverage collection |
+
+## Contribution Workflow
+
+### Branching
+
+1. **Always pull the latest `main`** before creating a new branch:
+
+   ```bash
+   git checkout main
+   git pull origin main
+   ```
+
+2. **Create your feature branch from `main`** using the naming convention:
+
+   | Branch Type | Pattern | Example |
+   |-------------|---------|---------|
+   | Feature | `feature/<short-description>` | `feature/add-retry-policy` |
+   | Bug fix | `bugfix/<short-description>` | `bugfix/connection-timeout` |
+   | Chore | `chore/<short-description>` | `chore/update-dependencies` |
+   | Release | `release/v<version>` | `release/v3.1.0` |
+   | Docs | `docsfix` or `docs/<description>` | `docs/update-readme` |
+
+   ```bash
+   git checkout -b feature/my-feature-name
+   ```
+
+### Commit Messages
+
+Write clear, descriptive commit messages. Follow these conventions:
+
+- Use **imperative mood** or a concise description of the change
+- Reference the PR number when applicable (GitHub adds this on squash-merge)
+- Keep the subject line under 72 characters
+
+**Examples of good commit messages:**
+
+```
+Add retry policy for transient ingestion errors
+Update Microsoft.Azure.Kusto.Ingest to ver. 14.1.0
+Fix connection string visibility issue
+ADXSinkE2ETest - increase timeout for flaky tests
+```
+
+### Pull Request Titles
+
+PR titles follow the same convention as commit messages — they should be clear and descriptive since PRs are squash-merged and the PR title becomes the commit message on `main`.
+
+**Examples of good PR titles:**
+
+```
+Microsoft.Azure.Kusto.Ingest ver. 14.1.0
+Support for AuthenticationType = AadWorkloadIdentity
+Fix connection timeout on batch ingestion
+Update test dependencies to latest stable versions
+```
+
+### Pull Request Guidelines
+
+- Target the `main` branch
+- Ensure CI passes (build + tests)
+- Provide a clear description of the change and why it is needed
+- Link related issues if applicable
+
+## CI/CD
+
+### Build & Test (`dotnet.yml`)
+
+- **Triggers:** Push to `main`, PRs targeting `main`
+- **Runs on:** `ubuntu-latest`
+- **Timeout:** 15 minutes
+- **Steps:** Restore → Build (Release) → Test (with ADX E2E environment)
+- **Environment:** `e2e` (provides `CONNECTION_STRING` and `DATABASE` vars)
+
+### NuGet Publish (`nuget.yml`)
+
+- **Trigger:** Manual (`workflow_dispatch`)
+- **Steps:** Restore → Build → Pack → Push to NuGet.org
+- **Secret:** `NUGET_API_KEY`
+
+## Architecture Notes
+
+### Core Pattern
+
+`ADXTarget` extends NLog's `AsyncTaskTarget`, which provides:
+
+- Async batching of log events
+- Configurable batch size, queue limits, and overflow behavior
+- Thread-safe lazy writer pattern
+
+### Ingestion Modes
+
+The target supports two ingestion modes:
+
+1. **Streaming ingestion** — Low latency, logs sent immediately via `IKustoIngestClient`
+2. **Queued ingestion** — Higher throughput, logs batched and queued via `IKustoQueuedIngestClient`
+
+### Authentication
+
+Authentication is configured via `AuthenticationType` enum and `KustoConnectionStringBuilder`. Supported modes:
+
+- Connection string (default)
+- AAD User Managed Identity
+- AAD System Managed Identity
+- AAD Workload Identity (Kubernetes)
+- Azure CLI
+- User Prompt (dev only)
+
+### Data Flow
+
+```
+LogEvent → ADXLogEvent (JSON) → GZip compress → MemoryStream → Kusto Ingest Client → ADX Table
+```
+
+Key implementation details:
+
+- Uses `RecyclableMemoryStreamManager` for efficient memory management
+- JSON serialization with custom `UnsafeRawJsonConverter` for properties
+- Automatic retry with skip for authentication and permanent errors
+- Connection string translation between engine and ingest endpoints

--- a/src/NLog.Azure.Kusto.Tests/ADXSinkE2ETest.cs
+++ b/src/NLog.Azure.Kusto.Tests/ADXSinkE2ETest.cs
@@ -15,6 +15,7 @@ namespace NLog.Azure.Kusto.Tests
         private readonly string m_generatedTableName = $"ADXNlogSink_{new Random().Next()}";
         private readonly KustoConnectionStringBuilder m_kustoConnectionStringBuilder;
         private readonly KustoConnectionStringBuilder m_kustoConnectionStringBuilderDM;
+        private readonly bool m_setupSucceeded;
 
         public ADXSinkE2ETest()
         {
@@ -52,28 +53,37 @@ namespace NLog.Azure.Kusto.Tests
 
             var refreshDmPolicies = CslCommandGenerator.GenerateDmRefreshPoliciesCommand();
 
-            WithTimeout("Setup Kusto", TimeSpan.FromSeconds(180), Task.Run(async () =>
+            try
             {
-                using ICslAdminProvider kustoClient = KustoClientFactory.CreateCslAdminProvider(m_kustoConnectionStringBuilder);
-                using ICslAdminProvider kustoClientDM = KustoClientFactory.CreateCslAdminProvider(m_kustoConnectionStringBuilderDM);
+                WithTimeout("Setup Kusto", TimeSpan.FromSeconds(180), Task.Run(async () =>
+                {
+                    using ICslAdminProvider kustoClient = KustoClientFactory.CreateCslAdminProvider(m_kustoConnectionStringBuilder);
+                    using ICslAdminProvider kustoClientDM = KustoClientFactory.CreateCslAdminProvider(m_kustoConnectionStringBuilderDM);
 
-                await WithTimeout("Create Kusto Tables", TimeSpan.FromSeconds(120), Task.Run(() =>
-                {
-                    kustoClient.ExecuteControlCommand(database, createTableCommand);
-                }));
-                await WithTimeout("Alter Kusto Batching", TimeSpan.FromSeconds(120), Task.Run(() =>
-                {
-                    kustoClient.ExecuteControlCommand(database, alterBatchingPolicy);
-                }));
-                await WithTimeout("Alter Kusto Streaming", TimeSpan.FromSeconds(120), Task.Run(() =>
-                {
-                    kustoClient.ExecuteControlCommand(database, enableStreamingIngestion);
-                }));
-                await WithTimeout("Create Kusto-DM Tables ", TimeSpan.FromSeconds(120), Task.Run(() =>
-                {
-                    kustoClientDM.ExecuteControlCommand(database, ".refresh database '" + database + "' table '" + m_generatedTableName + "' cache ingestionbatchingpolicy");
-                }));
-            })).Wait();
+                    await WithTimeout("Create Kusto Tables", TimeSpan.FromSeconds(120), Task.Run(() =>
+                    {
+                        kustoClient.ExecuteControlCommand(database, createTableCommand);
+                    }));
+                    await WithTimeout("Alter Kusto Batching", TimeSpan.FromSeconds(120), Task.Run(() =>
+                    {
+                        kustoClient.ExecuteControlCommand(database, alterBatchingPolicy);
+                    }));
+                    await WithTimeout("Alter Kusto Streaming", TimeSpan.FromSeconds(120), Task.Run(() =>
+                    {
+                        kustoClient.ExecuteControlCommand(database, enableStreamingIngestion);
+                    }));
+                    await WithTimeout("Create Kusto-DM Tables ", TimeSpan.FromSeconds(120), Task.Run(() =>
+                    {
+                        kustoClientDM.ExecuteControlCommand(database, ".refresh database '" + database + "' table '" + m_generatedTableName + "' cache ingestionbatchingpolicy");
+                    }));
+                })).Wait();
+                m_setupSucceeded = true;
+            }
+            catch (Exception ex)
+            {
+                m_setupSucceeded = false;
+                System.Diagnostics.Trace.WriteLine($"ADXSinkE2ETest setup failed: {ex.Message}");
+            }
         }
 
         private static async Task WithTimeout(string operationName, TimeSpan timeout, Task task)
@@ -87,6 +97,8 @@ namespace NLog.Azure.Kusto.Tests
         [InlineData("Test_ADXNTargetBatched", 10, 12, 5)]
         public async Task Test_LogMessage(string testType, int numberOfLogs, int retries, int delayTimeSecs)
         {
+            Assert.True(m_setupSucceeded, "Skipping test — ADX cluster setup failed (cluster may be unreachable)");
+
             Logger? logger = null;
 
             var stringWriter = new StringWriter();
@@ -197,19 +209,29 @@ namespace NLog.Azure.Kusto.Tests
 
         public void Dispose()
         {
-            WithTimeout("Dispose Kusto", TimeSpan.FromSeconds(120), Task.Run(() =>
+            try
             {
-                using (var queryProvider = KustoClientFactory.CreateCslAdminProvider(m_kustoConnectionStringBuilder))
+                if (!m_setupSucceeded)
+                    return;
+
+                WithTimeout("Dispose Kusto", TimeSpan.FromSeconds(30), Task.Run(() =>
                 {
-                    var command = CslCommandGenerator.GenerateTableDropCommand(m_generatedTableName);
-                    var clientRequestProperties = new ClientRequestProperties()
+                    using (var queryProvider = KustoClientFactory.CreateCslAdminProvider(m_kustoConnectionStringBuilder))
                     {
-                        ClientRequestId = Guid.NewGuid().ToString()
-                    };
-                    queryProvider.ExecuteControlCommand(Environment.GetEnvironmentVariable("DATABASE"), command,
-                        clientRequestProperties);
-                }
-            })).Wait();
+                        var command = CslCommandGenerator.GenerateTableDropCommand(m_generatedTableName);
+                        var clientRequestProperties = new ClientRequestProperties()
+                        {
+                            ClientRequestId = Guid.NewGuid().ToString()
+                        };
+                        queryProvider.ExecuteControlCommand(Environment.GetEnvironmentVariable("DATABASE"), command,
+                            clientRequestProperties);
+                    }
+                })).Wait();
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Trace.WriteLine($"ADXSinkE2ETest cleanup failed (non-fatal): {ex.Message}");
+            }
         }
     }
 }


### PR DESCRIPTION
- Add timeout-minutes: 15 to CI workflow to prevent infinite pipeline runs
- Update actions/checkout and actions/setup-dotnet to v4
- Add setup success tracking to E2E tests (fail fast if cluster unreachable)
- Wrap Dispose() in try/catch with reduced timeout (120s -> 30s)
- Skip table cleanup when setup failed (nothing to clean up)
- Add AGENTS.md with project guidance for AI agents